### PR TITLE
Log counters that are not incrememented when debug is set.

### DIFF
--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -43,6 +43,11 @@ function build_payload(metrics, time_stamp) {
     // Skip any counters that would not change the value
     if(v !== 0) {
       payload.push(p.inc(k, v, time_stamp));
+    } else {
+      // If debugging, log any counters that were not incrememented.
+      if(debug) {
+        util.puts("Skipping un-incremented counter: ", k);
+      }
     }
 
     var vps = metrics.counter_rates[k];


### PR DESCRIPTION
For tracking down some simple setup problems, it would be helpful to know when a counter wasn't being incremented as expected.